### PR TITLE
more precise rounding

### DIFF
--- a/main.js
+++ b/main.js
@@ -36,8 +36,8 @@ client.once("ready", async () => {
       await delay(5 * 1000)
       console.log("GAS", gas, "ETH/USD", Math.round(ethCost), "MIGRATION/USD", Math.round(USD))
       client.user.setStatus("available")
-      client.user.setActivity("Cost: $" + Math.round(USD) + " | Gas: " + gas, {
-        type: "PLAYING",
+      client.user.setActivity("Cost: $" + USD.toFixed(2) + " | Gas: " + gas, {
+        type: "WATCHING",
         url: "http://glm.golem.network/",
       })
     }


### PR DESCRIPTION
Now that Ethereum is cheaper again, I have changed the rounding to use toFixed(2) so that we can see more precise values. $1 really means that the estimate is >= $0.50 and < $1.50, which is a huge difference. While an estimate shouldn't be too precise, $0.50 or $1.50 of gas is a big difference for some users.

I've also switched PLAYING to WATCHING per a user suggestion from jedbrooke

Result:
![image](https://user-images.githubusercontent.com/64747030/174479691-ef437ca3-e550-4dd7-ae67-b4210323530e.png)
